### PR TITLE
fix: Add --skip-install for initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,7 @@ ENV ACCELERATE="True"
 RUN <<EOF
     set -eu
 
-    ./webui.sh --skip-torch-cuda-test --exit
+    ./webui.sh --skip-torch-cuda-test --skip-install --exit
 EOF
 
 ENTRYPOINT [ "./webui.sh", "--skip-torch-cuda-test", "--skip-install", "--listen", "--data-dir", "/data", "--xformers" ]


### PR DESCRIPTION
Fix exception during initialiation.

```plain
#31 12.67 Installing requirements
#31 12.76 Traceback (most recent call last):
#31 12.76   File "/code/stable-diffusion-webui/launch.py", line 48, in <module>
#31 12.76     main()
#31 12.76   File "/code/stable-diffusion-webui/launch.py", line 39, in main
#31 12.76     prepare_environment()
#31 12.76   File "/code/stable-diffusion-webui/modules/launch_utils.py", line 423, in prepare_environment
#31 12.76     run_pip(f"install -r \"{requirements_file}\"", "requirements")
#31 12.76   File "/code/stable-diffusion-webui/modules/launch_utils.py", line 144, in run_pip
#31 12.76     return run(f'"{python}" -m pip {command} --prefer-binary{index_url_line}', desc=f"Installing {desc}", errdesc=f"Couldn't install {desc}", live=live)
#31 12.76   File "/code/stable-diffusion-webui/modules/launch_utils.py", line 116, in run
#31 12.76     raise RuntimeError("\n".join(error_bits))
#31 12.76 RuntimeError: Couldn't install requirements.
#31 12.76 Command: "/opt/python_venv/bin/python3" -m pip install -r "requirements_versions.txt" --prefer-binary
#31 12.76 Error code: 1
#31 12.76 stderr: /opt/python_venv/bin/python3: No module named pip
#31 12.76 
#31 12.77 Traceback (most recent call last):
#31 12.77   File "/opt/python_venv/bin/accelerate", line 10, in <module>
#31 12.77     sys.exit(main())
#31 12.77   File "/opt/python_venv/lib/python3.10/site-packages/accelerate/commands/accelerate_cli.py", line 45, in main
#31 12.77     args.func(args)
#31 12.77   File "/opt/python_venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 979, in launch_command
#31 12.77     simple_launcher(args)
#31 12.77   File "/opt/python_venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 628, in simple_launcher
#31 12.77     raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
#31 12.77 subprocess.CalledProcessError: Command '['/opt/python_venv/bin/python3', 'launch.py', '--skip-torch-cuda-test', '--exit']' returned non-zero exit status 1.
```