### PR TITLE
fix: Use cuda base image for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.14
 ARG BASE_IMAGE="ubuntu:22.04"
+ARG BASE_RUNTIME_IMAGE=nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
 # Download the Python standalone build
 FROM ${BASE_IMAGE} AS download-python-stage
@@ -105,7 +106,7 @@ EOF
 
 
 # Build the runtime image
-FROM ${BASE_IMAGE} AS runtime-stage
+FROM ${BASE_RUNTIME_IMAGE} AS runtime-stage
 
 ARG DEBIAN_FRONTEND="noninteractive"
 RUN <<EOF


### PR DESCRIPTION
Fix onnxruntime-gpu exception when using WD14 tagger (https://github.com/picobyte/stable-diffusion-webui-wd14-tagger/tree/e72d984bdbed832ba83e2a443238c3851b9088ae).

```plain
Loading WD14 moat tagger v2 model file from SmilingWolf/wd-v1-4-moat-tagger-v2, model.onnx
2025-04-17 16:14:43.771844611 [E:onnxruntime:Default, provider_bridge_ort.cc:1480 TryGetProviderInfo_CUDA] /onnxruntime_src/onnxruntime/core/session/provider_bridge_ort.cc:1193 onnxruntime::Provider& onnxruntime::ProviderLibrary::Get() [ONNXRuntimeError] : 1 : FAIL : Failed to load library libonnxruntime_providers_cuda.so with error: libcurand.so.10: cannot open shared object file: No such file or directory

2025-04-17 16:14:43.771985373 [W:onnxruntime:Default, onnxruntime_pybind_state.cc:743 CreateExecutionProviderInstance] Failed to create CUDAExecutionProvider. Please reference https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements to ensure all dependencies are met.
Loaded WD14 moat tagger v2 model from SmilingWolf/wd-v1-4-moat-tagger-v2
```